### PR TITLE
Support multiple value headers

### DIFF
--- a/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -101,13 +101,13 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
 
         }
         if (!empty($settings[1])) {
-          $headers['OPTIONS']['Access-Control-Allow-Methods'] = explode(',', trim($settings[1]));
+          $headers['OPTIONS']['Access-Control-Allow-Methods'] = [ self::formatMultipleValueHeader($settings[1]) ];
         }
         if (!empty($settings[2])) {
-          $headers['OPTIONS']['Access-Control-Allow-Headers'] = explode(',', trim($settings[2]));
+          $headers['OPTIONS']['Access-Control-Allow-Headers'] = [ self::formatMultipleValueHeader($settings[2]) ];
         }
         if (!empty($settings[3])) {
-          $headers['all']['Access-Control-Allow-Credentials'] = explode(',', trim($settings[3]));
+          $headers['all']['Access-Control-Allow-Credentials'] = [ self::formatMultipleValueHeader($settings[3]) ];
         }
       }
     }
@@ -134,6 +134,16 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     $events[KernelEvents::RESPONSE][] = array('addCorsHeaders');
     return $events;
+  }
+
+  /**
+   * Helper function to format headers that might have multiple values.
+   *
+   * @param string $value
+   */
+  public static function formatMultipleValueHeader($value) {
+    $parts = array_map(trim, explode(',', $value));
+    return implode(', ', $parts);
   }
 
 }

--- a/src/Form/CorsAdminForm.php
+++ b/src/Form/CorsAdminForm.php
@@ -55,7 +55,7 @@ class CorsAdminForm extends ConfigFormBase {
           <li>*|http://example.com</li>
           <li>api|http://example.com:8080 http://example.com</li>
           <li>api/*|&lt;mirror&gt;,https://example.com</li>
-          <li>api/*|&lt;mirror&gt;|POST|Content-Type,Authorization|true</li>
+          <li>api/*|&lt;mirror&gt;|DELETE, POST|Content-Type,Authorization|true</li>
         </ul>'),
       '#default_value' => $cors_domains,
       '#rows' => 10,


### PR DESCRIPTION
I had problems with the `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` only outputting one of the values of the multiple ones given.

My configuration string looks like this:

    *|<mirror>|DELETE, GET, OPTIONS, POST, PUT|Content-Type,Authorization|true

This PR fixes that.